### PR TITLE
Fix eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,18 @@
 {
   "parser": "babel-eslint",
-    "extends": [
-      "standard"
+  "env": {
+    "browser": true
+  },
+  "extends": [
+    "standard"
     ],
-    "plugins": [
-      "babel"
-    ],
-    "rules": {
-      "key-spacing"          : 0,
-      "jsx-quotes"           : [2, "prefer-single"],
-      "max-len"              : [2, 120, 2],
-      "object-curly-spacing" : [2, "always"]
-    }
+  "plugins": [
+    "babel"
+  ],
+  "rules": {
+    "key-spacing"          : 0,
+    "jsx-quotes"           : [2, "prefer-single"],
+    "max-len"              : [2, 120, 2],
+    "object-curly-spacing" : [2, "always"]
+  }
 }

--- a/app/javascripts/app.js
+++ b/app/javascripts/app.js
@@ -1,102 +1,111 @@
 // Import the page's CSS. Webpack will know what to do with it.
-import "../stylesheets/app.css";
+import '../stylesheets/app.css'
 
 // Import libraries we need.
-import { default as Web3} from 'web3';
+import { default as Web3 } from 'web3'
 import { default as contract } from 'truffle-contract'
 
 // Import our contract artifacts and turn them into usable abstractions.
-import metacoin_artifacts from '../../build/contracts/MetaCoin.json'
+import metacoinArtifacts from '../../build/contracts/MetaCoin.json'
 
 // MetaCoin is our usable abstraction, which we'll use through the code below.
-var MetaCoin = contract(metacoin_artifacts);
+var MetaCoin = contract(metacoinArtifacts)
 
 // The following code is simple to show off interacting with your contracts.
 // As your needs grow you will likely need to change its form and structure.
 // For application bootstrapping, check out window.addEventListener below.
-var accounts;
-var account;
+var accounts
+var account
 
 window.App = {
-  start: function() {
-    var self = this;
+  start: function () {
+    var self = this
+    var web3 = window.web3
 
     // Bootstrap the MetaCoin abstraction for Use.
-    MetaCoin.setProvider(web3.currentProvider);
+    MetaCoin.setProvider(web3.currentProvider)
 
     // Get the initial account balance so it can be displayed.
-    web3.eth.getAccounts(function(err, accs) {
+    web3.eth.getAccounts(function (err, accs) {
       if (err != null) {
-        alert("There was an error fetching your accounts.");
-        return;
+        alert('There was an error fetching your accounts.')
+        return
       }
 
-      if (accs.length == 0) {
-        alert("Couldn't get any accounts! Make sure your Ethereum client is configured correctly.");
-        return;
+      if (accs.length === 0) {
+        alert("Couldn't get any accounts! Make sure your Ethereum client is configured correctly.")
+        return
       }
 
-      accounts = accs;
-      account = accounts[0];
+      accounts = accs
+      account = accounts[0]
 
-      self.refreshBalance();
-    });
+      self.refreshBalance()
+    })
   },
 
-  setStatus: function(message) {
-    var status = document.getElementById("status");
-    status.innerHTML = message;
+  setStatus: function (message) {
+    var status = document.getElementById('status')
+    status.innerHTML = message
   },
 
-  refreshBalance: function() {
-    var self = this;
+  refreshBalance: function () {
+    var self = this
 
-    var meta;
-    MetaCoin.deployed().then(function(instance) {
-      meta = instance;
-      return meta.getBalance.call(account, {from: account});
-    }).then(function(value) {
-      var balance_element = document.getElementById("balance");
-      balance_element.innerHTML = value.valueOf();
-    }).catch(function(e) {
-      console.log(e);
-      self.setStatus("Error getting balance; see log.");
-    });
+    var meta
+    MetaCoin.deployed().then(function (instance) {
+      meta = instance
+      return meta.getBalance.call(account, { from: account })
+    }).then(function (value) {
+      var balanceElement = document.getElementById('balance')
+      balanceElement.innerHTML = value.valueOf()
+    }).catch(function (e) {
+      console.log(e)
+      self.setStatus('Error getting balance; see log.')
+    })
   },
 
-  sendCoin: function() {
-    var self = this;
+  sendCoin: function () {
+    var self = this
 
-    var amount = parseInt(document.getElementById("amount").value);
-    var receiver = document.getElementById("receiver").value;
+    var amount = parseInt(document.getElementById('amount').value)
+    var receiver = document.getElementById('receiver').value
 
-    this.setStatus("Initiating transaction... (please wait)");
+    this.setStatus('Initiating transaction... (please wait)')
 
-    var meta;
-    MetaCoin.deployed().then(function(instance) {
-      meta = instance;
-      return meta.sendCoin(receiver, amount, {from: account});
-    }).then(function() {
-      self.setStatus("Transaction complete!");
-      self.refreshBalance();
-    }).catch(function(e) {
-      console.log(e);
-      self.setStatus("Error sending coin; see log.");
-    });
+    var meta
+    MetaCoin.deployed().then(function (instance) {
+      meta = instance
+      return meta.sendCoin(receiver, amount, { from: account })
+    }).then(function () {
+      self.setStatus('Transaction complete!')
+      self.refreshBalance()
+    }).catch(function (e) {
+      console.log(e)
+      self.setStatus('Error sending coin; see log.')
+    })
   }
-};
+}
 
-window.addEventListener('load', function() {
+window.addEventListener('load', function () {
   // Checking if Web3 has been injected by the browser (Mist/MetaMask)
   if (typeof web3 !== 'undefined') {
-    console.warn("Using web3 detected from external source. If you find that your accounts don't appear or you have 0 MetaCoin, ensure you've configured that source properly. If using MetaMask, see the following link. Feel free to delete this warning. :) http://truffleframework.com/tutorials/truffle-and-metamask")
+    console.warn('Using web3 detected from external source.',
+      'If you find that your accounts don\'t appear or you have 0 MetaCoin,',
+      'ensure you\'ve configured that source properly. If using MetaMask,',
+      'see the following link. Feel free to delete this warning. :)',
+      'http://truffleframework.com/tutorials/truffle-and-metamask')
     // Use Mist/MetaMask's provider
-    window.web3 = new Web3(web3.currentProvider);
+    window.web3 = new Web3(window.web3.currentProvider)
   } else {
-    console.warn("No web3 detected. Falling back to http://localhost:9545. You should remove this fallback when you deploy live, as it's inherently insecure. Consider switching to Metamask for development. More info here: http://truffleframework.com/tutorials/truffle-and-metamask");
+    console.warn('No web3 detected. Falling back to http://localhost:9545.',
+      'You should remove this fallback when you deploy live,',
+      'as it\'s inherently insecure. Consider switching to Metamask',
+      'for development. More info here:',
+      'http://truffleframework.com/tutorials/truffle-and-metamask')
     // fallback - use your fallback strategy (local node / hosted node + in-dapp id mgmt / fail)
-    window.web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:9545"));
+    window.web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:9545'))
   }
 
-  App.start();
-});
+  window.App.start()
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
+const path = require('path')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   entry: './app/javascripts/app.js',
@@ -10,14 +10,14 @@ module.exports = {
   plugins: [
     // Copy our app's index.html to the build folder.
     new CopyWebpackPlugin([
-      { from: './app/index.html', to: "index.html" }
+      { from: './app/index.html', to: 'index.html' }
     ])
   ],
   module: {
     rules: [
       {
-       test: /\.css$/,
-       use: [ 'style-loader', 'css-loader' ]
+        test: /\.css$/,
+        use: [ 'style-loader', 'css-loader' ]
       }
     ],
     loaders: [


### PR DESCRIPTION
This fixes the 89 errors from eslint (can be seen by running `npm run lint` in the base fork).

I think we can clean up the code a bit to minimize the global state; let me know if you'd like me to look into that!