### PR TITLE
Added truffle solidity loader into truffle box

### DIFF
--- a/app/scripts/index.js
+++ b/app/scripts/index.js
@@ -6,7 +6,7 @@ import { default as Web3 } from 'web3'
 import { default as contract } from 'truffle-contract'
 
 // Import our contract artifacts and turn them into usable abstractions.
-import metaCoinArtifact from '../../build/contracts/MetaCoin.json'
+import metaCoinArtifact from '../../contracts/MetaCoin.sol' // or '../../build/contracts/MetaCoin.json'
 
 // MetaCoin is our usable abstraction, which we'll use through the code below.
 const MetaCoin = contract(metaCoinArtifact)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "truffle-init-webpack",
-  "version": "0.0.2",
-  "description": "Frontend example using truffle v3",
+  "version": "0.1.0",
+  "description": "Frontend example using truffle v4",
   "scripts": {
     "test": "truffle test",
     "lint": "eslint ./",
@@ -40,6 +40,7 @@
     "web3": "^0.20.0",
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.6",
-    "webpack-dev-server": "^3.1.4"
+    "webpack-dev-server": "^3.1.4",
+    "truffle-solidity-loader": "^0.1.0"
   }
 }

--- a/truffle.js
+++ b/truffle.js
@@ -5,7 +5,7 @@ module.exports = {
   networks: {
     ganache: {
       host: '127.0.0.1',
-      port: 7545,
+      port: 9545,
       network_id: '*' // Match any network id
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,20 @@ module.exports = {
           presets: ['env'],
           plugins: ['transform-react-jsx', 'transform-object-rest-spread', 'transform-runtime']
         }
+      },
+      {
+        test: /\.sol/,
+        use: [
+          {
+            loader: 'json-loader'
+          },
+          {
+            loader: 'truffle-solidity-loader',
+            options: {
+              network: 'ganache'
+            }
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Updated the repo to work with truffle 4 and Truffle-solidity-loader. This will be used in a tutorial on how to use truffle-solidity-loader. I decided to to use this repo as oppose to using a new repo as to not confuse users with different webpack boxes. 