### PR TITLE
Added development mode to rapdily increase recompile speed

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = {
+  mode: 'development',
   entry: "./src/index.js",
   output: {
     filename: "index.js",


### PR DESCRIPTION
As per https://github.com/truffle-box/webpack-box/issues/17 the webpack currently takes a very long time to recompile whenever a slight change is made to anything. This is fixed by simply adding development mode. 

Please note this is my first PR (I am new to coding) so I may be doing something wrong here. If so please let me know....

Fixes #17 