### PR TITLE
Wait for emitted event before refreshing balance

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -17,6 +17,12 @@ const App = {
         metaCoinArtifact.abi,
         deployedNetwork.address,
       );
+      
+      // refresh balance and set status upon emitted event
+      this.meta.events.Transfer().on('data', (event) => {
+      this.refreshBalance(); 
+      this.setStatus("Transaction complete!");
+      })
 
       // get accounts
       const accounts = await web3.eth.getAccounts();
@@ -44,9 +50,6 @@ const App = {
 
     const { sendCoin } = this.meta.methods;
     await sendCoin(receiver, amount).send({ from: this.account });
-
-    this.setStatus("Transaction complete!");
-    this.refreshBalance();
   },
 
   setStatus: function(message) {


### PR DESCRIPTION
The original index.js said 'transaction complete' and refreshed the balance as soon as the transaction is issued- it does not wait for it to be confirmed. This does not make any difference when using a ganache or something similar but there will be a delay when using a public testnet or mainnet, so when it refreshes the balance, it will not update as the transaction will not be confirmed yet. 

Further, the solidity code already includes an event but it isn't used in index.js. This demonstrates how to use events. I personally have found it very difficult to figure out how to access emitted events using web3JS. 